### PR TITLE
Switch the runtime to node 12.x

### DIFF
--- a/module/main.tf
+++ b/module/main.tf
@@ -75,7 +75,7 @@ resource "aws_lambda_function" "basic_auth" {
   role             = "${aws_iam_role.lambda.arn}"
   handler          = "basic-auth.handler"
   source_code_hash = "${data.archive_file.basic_auth_function.output_base64sha256}"
-  runtime          = "nodejs8.10"
+  runtime          = "nodejs12.x"
   description      = "Protect CloudFront distributions with Basic Authentication"
   publish          = true
 }


### PR DESCRIPTION
The runtime parameter of nodejs8.10 is no longer supported for creating or updating AWS Lambda functions. We recommend you use the new runtime (nodejs12.x) while creating or updating functions