### PR TITLE
Add support for terraform >= 12

### DIFF
--- a/module/variables.tf
+++ b/module/variables.tf
@@ -1,10 +1,10 @@
 variable "function_name" {
-  type        = "string"
+  type        = string
   default     = "basicAuth"
   description = "Lambda function name"
 }
 
 variable "basic_auth_credentials" {
-  type        = "map"
+  type        = map
   description = "Credentials for Basic Authentication. Pass a map composed of 'user' and 'password'."
 }


### PR DESCRIPTION
Remove quotes from type constraints
```
Terraform 0.11 and earlier required type constraints to be given in quotes, but that form is now deprecated and will be removed in a future version of Terraform. Remove the quotes around "string".
```