### PR TITLE
Updating formatting to remove warnings

### DIFF
--- a/module/main.tf
+++ b/module/main.tf
@@ -55,8 +55,8 @@ EOF
 #
 
 data "template_file" "basic_auth_function" {
-  template = "${file("${path.module}/functions/basic-auth.js")}"
-  vars = "${var.basic_auth_credentials}"
+  template = file("${path.module}/functions/basic-auth.js")
+  vars = var.basic_auth_credentials
 }
 
 data "archive_file" "basic_auth_function" {
@@ -71,10 +71,10 @@ data "archive_file" "basic_auth_function" {
 
 resource "aws_lambda_function" "basic_auth" {
   filename         = "${path.module}/functions/basic-auth.zip"
-  function_name    = "${var.function_name}"
-  role             = "${aws_iam_role.lambda.arn}"
+  function_name    = var.function_name
+  role             = aws_iam_role.lambda.arn
   handler          = "basic-auth.handler"
-  source_code_hash = "${data.archive_file.basic_auth_function.output_base64sha256}"
+  source_code_hash = data.archive_file.basic_auth_function.output_base64sha256
   runtime          = "nodejs12.x"
   description      = "Protect CloudFront distributions with Basic Authentication"
   publish          = true

--- a/module/main.tf
+++ b/module/main.tf
@@ -30,7 +30,7 @@ EOF
 #
 
 resource "aws_iam_role_policy" "lambda" {
-  role = "${aws_iam_role.lambda.id}"
+  role = aws_iam_role.lambda.id
 
   policy = <<EOF
 {

--- a/module/main.tf
+++ b/module/main.tf
@@ -64,7 +64,7 @@ data "archive_file" "basic_auth_function" {
   output_path = "${path.module}/functions/basic-auth.zip"
 
   source {
-    content = "${data.template_file.basic_auth_function.rendered}"
+    content = data.template_file.basic_auth_function.rendered
     filename = "basic-auth.js"
   }
 }

--- a/module/outputs.tf
+++ b/module/outputs.tf
@@ -1,4 +1,4 @@
 output "lambda_arn" {
-  value       = "${aws_lambda_function.basic_auth.qualified_arn}"
+  value       = aws_lambda_function.basic_auth.qualified_arn
   description = "Lambda function ARN with version"
 }


### PR DESCRIPTION
When using the module in Terraform 0.14.5 warnings were issued on all `terraform` invocations regarding the deprecation of unnecessary string interpolations. This PR removes these warnings from triggering.