### PR TITLE
update runtime to nodejs18.x

### DIFF
--- a/module/main.tf
+++ b/module/main.tf
@@ -75,7 +75,7 @@ resource "aws_lambda_function" "basic_auth" {
   role             = "${aws_iam_role.lambda.arn}"
   handler          = "basic-auth.handler"
   source_code_hash = "${data.archive_file.basic_auth_function.output_base64sha256}"
-  runtime          = "nodejs12.x"
+  runtime          = "nodejs16.x"
   description      = "Protect CloudFront distributions with Basic Authentication"
   publish          = true
 }

--- a/module/main.tf
+++ b/module/main.tf
@@ -75,7 +75,7 @@ resource "aws_lambda_function" "basic_auth" {
   role             = "${aws_iam_role.lambda.arn}"
   handler          = "basic-auth.handler"
   source_code_hash = "${data.archive_file.basic_auth_function.output_base64sha256}"
-  runtime          = "nodejs16.x"
+  runtime          = "nodejs18.x"
   description      = "Protect CloudFront distributions with Basic Authentication"
   publish          = true
 }


### PR DESCRIPTION
`nodejs12.x` runtime is no longer supported:

```
│ Error: error creating Lambda Function (1): InvalidParameterValueException: The runtime parameter of nodejs12.x is no longer supported for creating or updating AWS Lambda functions. We recommend you use the new runtime (nodejs18.x) while creating or updating functions.
```